### PR TITLE
Add Atlas Cloud LiteLLM provider shortcut

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,12 @@ LLM_TEMPERATURE=0.7
 LLM_MAX_TOKENS=0
 LLM_TOP_P=0.80
 
+# Atlas Cloud shortcut for OpenAI-compatible chat/VLM models:
+#   LLM_MODEL=atlascloud/qwen/qwen3.5-flash
+#   VLM_MODEL=atlascloud/qwen/qwen3.5-flash
+ATLASCLOUD_API_KEY=
+ATLASCLOUD_API_BASE=https://api.atlascloud.ai/v1
+
 # ─── Embedder（litellm 统一格式）───
 EMBEDDING_BACKEND=litellm
 EMBEDDING_MODEL=

--- a/main.py
+++ b/main.py
@@ -44,12 +44,21 @@ def main():
 
 
 def _create_llm(settings):
+    from src.core.provider_resolver import resolve_litellm_model_provider
     from src.llm.litellm_llm import LiteLLMLLM
 
+    model, api_key, api_base = resolve_litellm_model_provider(
+        settings.llm_model,
+        api_key=settings.llm_api_key,
+        api_base=settings.llm_api_base,
+        atlascloud_api_key=getattr(settings, "atlascloud_api_key", ""),
+        atlascloud_api_base=getattr(settings, "atlascloud_api_base", ""),
+    )
+
     return LiteLLMLLM(
-        model=settings.llm_model,
-        api_key=settings.llm_api_key or None,
-        api_base=settings.llm_api_base or None,
+        model=model,
+        api_key=api_key,
+        api_base=api_base,
         default_temperature=settings.llm_temperature,
         default_max_tokens=(settings.llm_max_tokens if settings.llm_max_tokens > 0 else None),
         default_top_p=settings.llm_top_p,

--- a/src/core/config.py
+++ b/src/core/config.py
@@ -10,6 +10,8 @@ from pathlib import Path
 from dotenv import load_dotenv
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
+from src.core.provider_resolver import ATLASCLOUD_API_BASE
+
 # 在 Settings 初始化前，显式加载 .env 文件
 # override=True 确保 .env 中的值优先于系统环境变量
 # （开发环境约定：.env 提高优先级）
@@ -28,6 +30,8 @@ class Settings(BaseSettings):
     llm_max_tokens: int = 0  # 0 = 不限制，交给 provider 默认
     llm_top_p: float = 0.80
 
+    atlascloud_api_key: str = ""
+    atlascloud_api_base: str = ATLASCLOUD_API_BASE
 
     embedding_model: str = "openai/text-embedding-3-small"
     embedding_dim: int = 0  # 0 = 自动探测（启动时调用一次 API 获取实际维度）

--- a/src/core/factory.py
+++ b/src/core/factory.py
@@ -231,12 +231,29 @@ def create_pipeline(
                 vlm_model, 
                 getattr(global_settings, "vlm_api_base", "NOT SET"))
     if vlm_model:
+        from src.core.provider_resolver import resolve_litellm_model_provider
         from src.llm.litellm_llm import LiteLLMLLM
 
+        resolved_vlm_model, resolved_vlm_api_key, resolved_vlm_api_base = (
+            resolve_litellm_model_provider(
+                vlm_model,
+                api_key=(
+                    getattr(global_settings, "vlm_api_key", "")
+                    or getattr(global_settings, "llm_api_key", "")
+                ),
+                api_base=(
+                    getattr(global_settings, "vlm_api_base", "")
+                    or getattr(global_settings, "llm_api_base", "")
+                ),
+                atlascloud_api_key=getattr(global_settings, "atlascloud_api_key", ""),
+                atlascloud_api_base=getattr(global_settings, "atlascloud_api_base", ""),
+            )
+        )
+
         vlm_llm = LiteLLMLLM(
-            model=vlm_model,
-            api_key=getattr(global_settings, "vlm_api_key", global_settings.llm_api_key),
-            api_base=getattr(global_settings, "vlm_api_base", global_settings.llm_api_base),
+            model=resolved_vlm_model,
+            api_key=resolved_vlm_api_key,
+            api_base=resolved_vlm_api_base,
             default_temperature=getattr(global_settings, "vlm_temperature", 0.7),
             default_max_tokens=(
                 getattr(global_settings, "vlm_max_tokens", 0)

--- a/src/core/provider_resolver.py
+++ b/src/core/provider_resolver.py
@@ -1,0 +1,34 @@
+"""Provider-specific helpers for LiteLLM-backed model configuration."""
+
+from __future__ import annotations
+
+ATLASCLOUD_API_BASE = "https://api.atlascloud.ai/v1"
+ATLASCLOUD_MODEL_PREFIX = "atlascloud/"
+
+
+def resolve_litellm_model_provider(
+    model: str,
+    *,
+    api_key: str | None = None,
+    api_base: str | None = None,
+    atlascloud_api_key: str | None = None,
+    atlascloud_api_base: str | None = None,
+) -> tuple[str, str | None, str | None]:
+    """Resolve project-level provider shortcuts into LiteLLM arguments."""
+
+    normalized_model = (model or "").strip()
+    resolved_api_key = api_key or None
+    resolved_api_base = api_base or None
+
+    if not normalized_model.lower().startswith(ATLASCLOUD_MODEL_PREFIX):
+        return normalized_model, resolved_api_key, resolved_api_base
+
+    atlas_model = normalized_model[len(ATLASCLOUD_MODEL_PREFIX) :].strip()
+    if not atlas_model:
+        raise ValueError("atlascloud/ model names must include a model id")
+
+    return (
+        f"openai/{atlas_model}",
+        resolved_api_key or atlascloud_api_key or None,
+        resolved_api_base or atlascloud_api_base or ATLASCLOUD_API_BASE,
+    )

--- a/tests/test_atlascloud_provider_resolver.py
+++ b/tests/test_atlascloud_provider_resolver.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from main import _create_llm
+from src.core.provider_resolver import (
+    ATLASCLOUD_API_BASE,
+    resolve_litellm_model_provider,
+)
+
+
+def _settings(**overrides):
+    values = {
+        "llm_model": "atlascloud/qwen/qwen3.5-flash",
+        "llm_api_key": "",
+        "llm_api_base": "",
+        "llm_temperature": 0.7,
+        "llm_max_tokens": 0,
+        "llm_top_p": 0.8,
+        "atlascloud_api_key": "atlas-key",
+        "atlascloud_api_base": ATLASCLOUD_API_BASE,
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def test_atlascloud_shortcut_maps_to_openai_compatible_litellm_args() -> None:
+    llm = _create_llm(_settings())
+
+    assert llm.model == "openai/qwen/qwen3.5-flash"
+    assert llm._api_key == "atlas-key"
+    assert llm._api_base == ATLASCLOUD_API_BASE
+
+
+def test_explicit_llm_config_overrides_atlascloud_defaults() -> None:
+    llm = _create_llm(
+        _settings(
+            llm_model="atlascloud/deepseek-ai/deepseek-v4-pro",
+            llm_api_key="proxy-key",
+            llm_api_base="https://proxy.example/v1",
+        )
+    )
+
+    assert llm.model == "openai/deepseek-ai/deepseek-v4-pro"
+    assert llm._api_key == "proxy-key"
+    assert llm._api_base == "https://proxy.example/v1"
+
+
+def test_non_atlascloud_model_is_left_unchanged() -> None:
+    model, api_key, api_base = resolve_litellm_model_provider(
+        "openai/gpt-4o-mini",
+        api_key="openai-key",
+        api_base="https://openai-compatible.example/v1",
+        atlascloud_api_key="atlas-key",
+    )
+
+    assert model == "openai/gpt-4o-mini"
+    assert api_key == "openai-key"
+    assert api_base == "https://openai-compatible.example/v1"
+
+
+def test_atlascloud_shortcut_requires_a_model_id() -> None:
+    with pytest.raises(ValueError, match="model id"):
+        resolve_litellm_model_provider("atlascloud/")


### PR DESCRIPTION
## Summary
- add an `atlascloud/<model>` shortcut that resolves to LiteLLM's OpenAI-compatible `openai/<model>` route
- read Atlas Cloud defaults from `ATLASCLOUD_API_KEY` and `ATLASCLOUD_API_BASE`, while preserving explicit `LLM_API_*` / `VLM_API_*` overrides
- apply the shortcut to both the primary LLM path and optional VLM path, with focused tests for the resolver behavior

## Validation
- `.venv311/bin/python -m pytest tests/test_atlascloud_provider_resolver.py -q` (4 passed; pytest warns about existing `asyncio_mode` when pytest-asyncio is not installed)
- `.venv311/bin/python -m compileall main.py src/core/provider_resolver.py src/core/config.py src/core/factory.py tests/test_atlascloud_provider_resolver.py`
- `/Users/zby/.local/bin/uvx ruff check main.py src/core/provider_resolver.py src/core/config.py src/core/factory.py tests/test_atlascloud_provider_resolver.py`
- `git diff --check`
- Atlas Cloud live model catalog check confirmed `qwen/qwen3.5-flash` and `deepseek-ai/deepseek-v4-pro`

No README or promotional sections were changed.
